### PR TITLE
remove NODE_ENV variables from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "scripts": {
     "dev": "greenwood develop",
-    "build": "NODE_ENV=production greenwood build",
-    "serve": "NODE_ENV=production greenwood serve",
+    "build": "greenwood build",
+    "serve": "greenwood serve",
     "story:dev": "storybook dev -p 6006",
     "story:build": "storybook build",
     "story:serve": "storybook build && http-server ./storybook-static",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. I think must have been a copy / 🍝 , not sure `NODE_ENV` is something we need here