### PR TITLE
fix the hex value for accent theme color in tailwind config

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -7,7 +7,7 @@ module.exports = {
       colors: {
         primary: '#189992',
         secondary: '#60f1ac',
-        accent: '##f66',
+        accent: '#f66',
         white: '#efefef',
         black: '#020202',
         gray: '#72674c'


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#13 

## Summary of Changes
1. Realized there was an errant `#` in the accent color value in _tailwind.config.js_