### PR TITLE
update theme color guidelines for WCAG AA compliance

### DIFF
--- a/src/stories/Styleguide.stories.mdx
+++ b/src/stories/Styleguide.stories.mdx
@@ -31,12 +31,20 @@ import { Meta } from '@storybook/addon-docs';
       background-color: var(--color-accent);
     }
 
+    .palette-tertiary {
+      background-color: var(--color-tertiary);
+    }
+
     .palette-white {
       background-color: var(--color-white);
     }
 
     .palette-black {
       background-color: var(--color-black);
+    }
+
+    .typography {
+      font-size: 1.4rem;
     }
 
     .typography-primary {
@@ -73,7 +81,14 @@ The following theme colors available are:
 
 ### `--color-accent`
 
+> _Guidelines_
+> - Should not be used for small text on white backgrounds
+
 <span class="palette-box palette-accent"></span>
+
+### `--color-tertiary`
+
+<span class="palette-box palette-tertiary"></span>
 
 ### `--color-white`
 
@@ -89,11 +104,11 @@ The following font families available are:
 
 ### Montserrat Regular
 
-<span class="typography-primary">The quick brown fox jumped over the lazy dog.</span>
+<span class="typography typography-primary">The quick brown fox jumped over the lazy dog.</span>
 
 ### Citrus Gothic Rough Regular
 
-<span class="typography-secondary">The quick brown fox jumped over the lazy dog.</span>
+<span class="typography typography-secondary">The quick brown fox jumped over the lazy dog.</span>
 
 ## Design System
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -16,9 +16,10 @@
 
 :root,
 :host {
-  --color-primary: #189992;
-  --color-secondary: #60f1ac;
-  --color-accent: #f66;
+  --color-primary: #026769;
+  --color-secondary: #60eda8;
+  --color-accent: #ff5c5c;
+  --color-tertiary: #fcc;
   --color-white: #efefef;
   --color-black: #020202;
   --color-gray: #72674c;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,9 +5,10 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#189992',
-        secondary: '#60f1ac',
-        accent: '#f66',
+        primary: '#026769',
+        secondary: '#60eda8',
+        accent: '#ff5c5c',
+        tertiary: '#fcc',
         white: '#efefef',
         black: '#020202',
         gray: '#72674c'


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #18 

## Summary of Changes
1. Adjusted theme colors to work in better text / background color scenarios while achieving WCAG AA compliance
1. Added new `--color-tertiary` custom property
1. Update theme and styleguide documentation

![Screen Shot 2023-03-18 at 8 42 59 PM](https://user-images.githubusercontent.com/895923/226148507-3bf63d73-80a8-4d71-a8a7-002643bc1722.png)
![Screen Shot 2023-03-18 at 9 08 36 PM](https://user-images.githubusercontent.com/895923/226148510-17e704c5-cd98-44e5-8dc2-4d0727026dd0.png)

> _Note: the **ca4969** in the first screenshot was further tweaked to the value seen here in this PR to retain the salmon / lobster color.  that will be updated in the next iteration of the Styleguide PDF_