### PR TITLE
set signup form `<input>` text color to dark to improve contrast and legibility

### DIFF
--- a/src/components/signup-form/signup-form.js
+++ b/src/components/signup-form/signup-form.js
@@ -30,7 +30,7 @@ export default class SignupForm extends HTMLElement {
             Name (optional)
             <input
               type="text"
-              class="w-full p-2 rounded-lg"
+              class="w-full p-2 rounded-lg text-black"
               name="name"
             />
           </label>
@@ -39,7 +39,7 @@ export default class SignupForm extends HTMLElement {
             <input
               type="email"
               name="email"
-              class="w-full p-2 rounded-lg"
+              class="w-full p-2 rounded-lg text-black"
               required
             />
           </label>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #6 , color contrast for `<input>`s is hard to read in the signup form component
![Screen Shot 2023-04-02 at 7 27 28 PM](https://user-images.githubusercontent.com/895923/229384854-a4148971-5f11-4e2e-9d29-bf7f780ac0bd.png)


## Summary of Changes
1. Set `<input>` color to `text-black`
![Screen Shot 2023-04-02 at 7 28 34 PM](https://user-images.githubusercontent.com/895923/229384863-25e97a5e-c09e-4d99-adc7-13d4f585e63d.png)
