### PR TITLE
bug/use root relative paths for font files

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -4,13 +4,13 @@
 
 @font-face {
   font-family: 'Montserrat';
-  src: url('../assets/fonts/montserrat-regular.ttf') format('ttf');
+  src: url('/assets/fonts/montserrat-regular.ttf') format('ttf');
   font-display: swap;
 }
 
 @font-face {
   font-family: 'Citrus Gothic';
-  src: url('../assets/fonts/citrus-gothic-rough-regular.woff2') format('woff2');
+  src: url('/assets/fonts/citrus-gothic-rough-regular.woff2') format('woff2');
   font-display: swap;
 }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #59 , as observed when testing locally, due to the `../` on deeply nested paths the fonts were not loading. so this is a preemptive bug fix. (Note: it should be `404`, not a `500` - see #86 )
![Screen Shot 2023-05-24 at 9 03 03 AM](https://github.com/AnalogStudiosRI/www.blissfestri.com/assets/895923/fe340925-af8d-48fe-9f8f-79073fc4488a)


## Summary of Changes
1. Make font paths relative to the root - `/`