### PR TITLE
fix blissfest facebook footer link labels

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -8,13 +8,13 @@ export default class Footer extends HTMLElement {
           <div class="flex gap-x-4 justify-center mb-4">
             <a
               href="https://www.facebook.com/blissfestri/"
-              aria-label="Analog Studios Facebook page"
+              aria-label="Blissfest Facebook page"
               target="_blank"
               class="ml-2 mr-2"
             >
               <img
                 src="/assets/images/facebook-icon.png"
-                alt="Analog Studios Facebook page"
+                alt="Blissfest Facebook page"
                 width="40"
                 height="40"
                 loading="lazy"

--- a/src/components/footer/footer.spec.js
+++ b/src/components/footer/footer.spec.js
@@ -25,7 +25,7 @@ describe('Components/Footer', () => {
 
     describe('Social Icon Links', () => {
       it('should have the expected Facebook social link icon', () => {
-        const facebookLink = document.querySelectorAll('a[aria-label="Analog Studios Facebook page"]');
+        const facebookLink = document.querySelectorAll('a[aria-label="Blissfest Facebook page"]');
         const facebookImage = facebookLink[0].querySelectorAll('img');
 
         expect(facebookLink.length).to.equal(1);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #49 

## Summary of Changes
1. Fix Blissfest facebook footer link labels