### PR TITLE
Feature/add promo video to home page

### DIFF
--- a/src/components/promo-video/promo-video.js
+++ b/src/components/promo-video/promo-video.js
@@ -4,6 +4,7 @@ export default class PromoVideo extends HTMLElement {
       <iframe
         class="w-full aspect-video"
         src="https://www.youtube.com/embed/-zazqdr-g6A"
+        title="Blissfest Promotional Video"
         loading="lazy"
       ></iframe>
     `;

--- a/src/components/promo-video/promo-video.js
+++ b/src/components/promo-video/promo-video.js
@@ -1,0 +1,13 @@
+export default class PromoVideo extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <iframe
+        class="w-full aspect-video"
+        src="https://www.youtube.com/embed/-zazqdr-g6A"
+        loading="lazy"
+      ></iframe>
+    `;
+  }
+}
+
+customElements.define('bf-promo-video', PromoVideo);

--- a/src/components/promo-video/promo-video.spec.js
+++ b/src/components/promo-video/promo-video.spec.js
@@ -31,6 +31,10 @@ describe('Components/Promo Video', () => {
     it('should have the loading attribute for the iframe', () => {
       expect(frame.getAttribute('loading')).to.equal('lazy');
     });
+
+    it('should have the title attribute for the iframe', () => {
+      expect(frame.getAttribute('title')).to.equal('Blissfest Promotional Video');
+    });
   });
 
   after(() => {

--- a/src/components/promo-video/promo-video.spec.js
+++ b/src/components/promo-video/promo-video.spec.js
@@ -1,0 +1,41 @@
+import { expect } from '@esm-bundle/chai';
+import './promo-video.js';
+
+describe('Components/Promo Video', () => {
+  let promo;
+
+  before(async () => {
+    promo = document.createElement('bf-promo-video');
+    document.body.appendChild(promo);
+
+    await promo.updateComplete;
+  });
+
+  describe('Default Behavior', () => {
+    let frame;
+
+    beforeEach(() => {
+      frame = promo.querySelector('iframe');
+    });
+
+    it('should not be null', () => {
+      expect(promo).not.equal(undefined);
+      expect(frame).not.equal(undefined);
+      expect(promo.querySelectorAll('iframe').length).equal(1);
+    });
+
+    it('should have the expected src attribute for the iframe', () => {
+      expect(frame.getAttribute('src')).to.equal('https://www.youtube.com/embed/-zazqdr-g6A');
+    });
+
+    it('should have the loading attribute for the iframe', () => {
+      expect(frame.getAttribute('loading')).to.equal('lazy');
+    });
+  });
+
+  after(() => {
+    promo.remove();
+    promo = null;
+  });
+
+});

--- a/src/components/promo-video/promo-video.stories.js
+++ b/src/components/promo-video/promo-video.stories.js
@@ -1,0 +1,10 @@
+import '../../styles/theme.css';
+import './promo-video.js';
+
+export default {
+  title: 'Components/Promo Video'
+};
+
+const Template = () => '<bf-promo-video></bf-promo-video>';
+
+export const Primary = Template.bind({});

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -5,6 +5,7 @@
     <script type="module" src="../components/ticket-info/ticket-info.js" data-gwd-opt="static"></script>
     <script type="module" src="../components/newsletter-signup/newsletter-signup.js" data-gwd-opt="static"></script>
     <script type="module" src="../components/lineup-poster/lineup-poster.js" data-gwd-opt="static"></script>
+    <script type="module" src="../components/promo-video/promo-video.js" data-gwd-opt="static"></script>
   </head>
 
   <body>
@@ -36,6 +37,10 @@
         <bf-lineup-poster
           class="block mt-8"
         ></bf-lineup-poster>
+
+        <bf-promo-video
+          class="block mt-8"
+        ></bf-promo-video>
 
         <bf-newsletter-signup
           class="block mt-8"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
relates to #56 

## Summary of Changes
1. Create a `PromoVideo` component
1. Add promo video to the home page

---

> **Note**: _Created a tracking item for some of the Lighthouse recommendations seen when auditing the page with the YouTube embed on it - https://github.com/AnalogStudiosRI/www.blissfestri.com/issues/119_