### PR TITLE
enable promo video to played in fullscreen

### DIFF
--- a/src/components/promo-video/promo-video.js
+++ b/src/components/promo-video/promo-video.js
@@ -5,6 +5,7 @@ export default class PromoVideo extends HTMLElement {
         class="w-full aspect-video"
         src="https://www.youtube.com/embed/-zazqdr-g6A"
         title="Blissfest Promotional Video"
+        allowfullscreen
         loading="lazy"
       ></iframe>
     `;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #118 

Noticed that we were not allowing fullscreen mode
![Screen Shot 2023-06-25 at 1 09 43 PM](https://github.com/AnalogStudiosRI/www.blissfestri.com/assets/895923/ab560f30-33c2-4371-b273-16efdd2144d7)

## Summary of Changes
1. Allow fullscreen for `PromoVideo` component