### PR TITLE
301 redirects netlify configuration to new domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,11 @@
 [build.environment]
   NODE_VERSION = "18.12.1"
   TZ = "America/New_York"
+
+# https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects
+# https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file
+[[redirects]]
+  from = "/*"
+  to = "https://www.blissri.com/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
https://github.com/AnalogStudiosRI/www.blissri.com/issues/1

## Summary of Changes
1. Setup Netlify `301` redirect to new domain